### PR TITLE
Adaptar darcnesevolved para sdl2 y windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,111 @@
+# Simple cross-platform Makefile for darcnesevolved
+# Supports Linux/macOS and Windows (MSYS2/MinGW, mingw32-make)
+
+# Tools
+CC ?= gcc
+CXX ?= g++
+AR ?= ar
+RM ?= rm -f
+MKDIR ?= mkdir -p
+
+# Build dirs
+BUILDDIR := build
+OBJDIR := $(BUILDDIR)/obj
+BINDIR := $(BUILDDIR)/bin
+
+# Source discovery
+CPP_SOURCES := $(wildcard src/*.cpp)
+C_SOURCES := $(wildcard src/*.c)
+
+# Targets
+ZX_MAIN := zx48k
+MINIVADR := minivadr
+SCRVIEW := scrview
+
+# Filter sources per target
+ZX_SOURCES := $(filter-out src/minivadr_main.cpp,$(CPP_SOURCES))
+MINIVADR_SOURCES := src/minivadr_main.cpp
+SCRVIEW_SOURCES := src/main.c
+
+# Objects
+ZX_OBJS := $(patsubst src/%.cpp,$(OBJDIR)/%.o,$(ZX_SOURCES))
+MINIVADR_OBJS := $(patsubst src/%.cpp,$(OBJDIR)/%.o,$(MINIVADR_SOURCES))
+SCRVIEW_OBJS := $(patsubst src/%.c,$(OBJDIR)/%.o,$(SCRVIEW_SOURCES))
+
+# Detect platform for SDL2 linking quirks
+OS_NAME := $(shell uname -s 2>/dev/null || echo Windows)
+IS_WINDOWS := 0
+ifeq ($(OS),Windows_NT)
+  IS_WINDOWS := 1
+endif
+ifneq (,$(findstring MINGW,$(OS_NAME)))
+  IS_WINDOWS := 1
+endif
+
+# Compiler flags
+CXXFLAGS ?= -std=c++17 -Wall -Wextra -Wpedantic -O2
+CFLAGS ?= -Wall -Wextra -O2
+CPPFLAGS ?=
+LDFLAGS ?=
+
+# SDL2 flags: try pkg-config first, else SDL2DIR
+PKG_CONFIG := $(shell command -v pkg-config 2>/dev/null)
+ifdef PKG_CONFIG
+  SDL2_CFLAGS := $(shell pkg-config --cflags sdl2 2>/dev/null)
+  SDL2_LIBS := $(shell pkg-config --libs sdl2 2>/dev/null)
+endif
+
+ifeq ($(strip $(SDL2_CFLAGS)),)
+  ifneq ($(strip $(SDL2DIR)),)
+    SDL2_CFLAGS := -I"$(SDL2DIR)/include"
+    ifeq ($(IS_WINDOWS),1)
+      # Prefer MinGW import libs in SDL2DIR
+      SDL2_LIBS := -L"$(SDL2DIR)/lib" -lSDL2
+    else
+      SDL2_LIBS := -L"$(SDL2DIR)/lib" -lSDL2
+    endif
+  endif
+endif
+
+# On Windows with MinGW, linking SDL2main can be helpful; keep optional
+ifeq ($(IS_WINDOWS),1)
+  SDL2_LIBS += -lSDL2main
+  # Some MinGW setups need -lmingw32 first
+  SDL2_LIBS := -lmingw32 $(SDL2_LIBS)
+endif
+
+# Defines: enable SDL code paths
+CPPFLAGS += -DZX_WITH_SDL=1
+
+.PHONY: all clean dirs
+
+all: dirs $(BINDIR)/$(ZX_MAIN) $(BINDIR)/$(MINIVADR) $(BINDIR)/$(SCRVIEW)
+
+dirs:
+	$(MKDIR) $(OBJDIR) $(BINDIR)
+
+# Link rules
+$(BINDIR)/$(ZX_MAIN): $(ZX_OBJS)
+	$(CXX) $(LDFLAGS) -o $@ $^ $(SDL2_LIBS)
+
+$(BINDIR)/$(MINIVADR): $(MINIVADR_OBJS)
+	$(CXX) $(LDFLAGS) -o $@ $^ $(SDL2_LIBS)
+
+$(BINDIR)/$(SCRVIEW): $(SCRVIEW_OBJS)
+	$(CC) $(LDFLAGS) -o $@ $^ $(SDL2_LIBS)
+
+# Compile rules
+$(OBJDIR)/%.o: src/%.cpp | dirs
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(SDL2_CFLAGS) -c $< -o $@
+
+$(OBJDIR)/%.o: src/%.c | dirs
+	$(CC) $(CPPFLAGS) $(CFLAGS) $(SDL2_CFLAGS) -c $< -o $@
+
+clean:
+	$(RM) -r $(BUILDDIR)
+
+# Convenience run target (Linux/macOS): make run ROM=48.rom SNAP=game.sna
+.PHONY: run
+run: $(BINDIR)/$(ZX_MAIN)
+	$(BINDIR)/$(ZX_MAIN) $(ROM) $(SNAP)
+

--- a/README.md
+++ b/README.md
@@ -24,6 +24,29 @@ cmake --build build -j
 
 Binary will be at `build/bin/zx48k`.
 
+### Windows (MSYS2/MinGW) via Makefile
+
+Optionally, you can build with the provided Makefile which is friendly to Windows environments:
+
+1. Install MSYS2 and MinGW toolchain, then install SDL2:
+```bash
+pacman -S --needed mingw-w64-x86_64-toolchain mingw-w64-x86_64-SDL2 make
+```
+2. Open an MSYS2 MinGW64 shell and run:
+```bash
+mingw32-make
+```
+
+If `pkg-config` is not available, set `SDL2DIR` to your SDL2 install prefix:
+```bash
+mingw32-make SDL2DIR="C:/msys64/mingw64"
+```
+
+Artifacts will be in `build/bin/`:
+- `zx48k` main emulator
+- `minivadr` MiniVadr sample (requires `minivadr_main.cpp`)
+- `scrview` simple `.scr` viewer
+
 ## Run
 
 You need a 48K Spectrum ROM (16KB). Place it somewhere and pass the path. Optionally pass a 48K `.sna` snapshot to start directly into a program.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -7,7 +7,7 @@
 #include <chrono>
 
 #ifndef ZX_HEADLESS
-#include <SDL.h>
+#include <SDL2/SDL.h>
 #endif
 
 #include "z80.h"


### PR DESCRIPTION
Add a cross-platform Makefile and standardize SDL2 includes to enable Windows compilation.

---
<a href="https://cursor.com/background-agent?bcId=bc-ad6b5974-4c72-4079-a7e3-2878ac2fbffd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ad6b5974-4c72-4079-a7e3-2878ac2fbffd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

